### PR TITLE
Fix typo

### DIFF
--- a/uni-titlepage.dtx
+++ b/uni-titlepage.dtx
@@ -602,7 +602,7 @@ KOMA presents the title page project
 % \label{sec:Style-JT-Aufsaetze}
 %
 % The style is based on the front cover of ``Jan Tschichold: Ausgewählte
-% Aufsätze über Fragen der Gestalt des Buches und der Typüographie, Birkhäuser
+% Aufsätze über Fragen der Gestalt des Buches und der Typographie, Birkhäuser
 % Verlag Basel, 1975, ISBN: 3-7643-1946-1''. I've made this, because the book
 % is a major book of classic typography. It seems to be old fashioned and indeed
 % it is. Note, that the front cover of a book an the main title of a book are


### PR DESCRIPTION
The current manual contains a little typo. This PR fixes it.

![grafik](https://user-images.githubusercontent.com/1366654/160213478-f822b85e-f372-4641-aff4-5d2a6cf1ae05.png)
