### PR TITLE
Add link

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,10 @@ a TDS tree. All files `titlepage-*.tex` and `titlepage-*.pdf` as well as
 # Unpacking and Installation for Users
 
 Users can use the installation described at
-[Unpacking and Installation for Developers and Distributors]. However, if
-your TeX distributor already distributes a ready for installation package, you
-do not need and should not create files and copy them yourself. Just use the
-package manager of your TeX distribution to install the package.
+[Unpacking and Installation for Developers and Distributors](#unpacking-and-installation-for-developers-and-distributors).
+However, if your TeX distributor already distributes a ready for installation
+package, you do not need and should not create files and copy them yourself. Just
+use the package manager of your TeX distribution to install the package.
 
 # How to Contribute
 


### PR DESCRIPTION
This adds a link to the section. Markdown does not allow `](` being separated, therefore, I put it at the same line. I needed to rewrap the text following the link.

Before:

![grafik](https://user-images.githubusercontent.com/1366654/183853393-fede65b6-bbd0-4650-879f-dd3fe47e32f4.png)

After:

![grafik](https://user-images.githubusercontent.com/1366654/183853321-66e335e2-3f8e-4860-b95d-84021e9377f8.png)
