### PR TITLE
fix: Remove recursive expansion of germanordinalfemalerefereename

### DIFF
--- a/uni-titlepage.dtx
+++ b/uni-titlepage.dtx
@@ -1939,7 +1939,7 @@ You may however distribute the file `uni-titlepage.dtx' without this file.
 % \changes{v0.7}{2021/08/18}{added}
 %    \begin{macrocode}
 \newcommand*{\germanordinalfemalerefereename}[1]{%
-  \germanordinalfemalerefereename{#1}in%
+  \germanordinalmalerefereename{#1}in%
 }
 %    \end{macrocode}
 % \end{imacro}


### PR DESCRIPTION
Current use of said command will lead to recursive, non-terminating expansion and thus fails.
It seems like it was intended to invoke the male version and append `in`, so do just that.